### PR TITLE
update the dependencies and set mirror links

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "electron ./main.js",
     "dev": "electron ./main_dev.js",
-    "package_all": "electron-packager ./ bbg --asar --overwrite --platform=win32,linux,darwin,mas  --arch=x64 --download.mirrorOptions.mirror=https://registry.npmmirror.com/electron/ --electron-version=16.2.2",
-    "package_windows": "electron-packager ./ bbg --asar --overwrite --platform=win32  --arch=x64 --download.mirrorOptions.mirror=https://registry.npmmirror.com/electron/ --electron-version=16.2.2",
-    "package_linux": "electron-packager ./ bbg --asar --overwrite --platform=linux  --arch=x64 --download.mirrorOptions.mirror=https://registry.npmmirror.com/electron/  --electron-version=16.2.2",
-    "package_darwin": "electron-packager ./ bbg --asar --overwrite --platform=darwin  --arch=x64 --download.mirrorOptions.mirror=https://registry.npmmirror.com/electron/  --electron-version=16.2.2",
-    "package_mas": "electron-packager ./ bbg --asar --overwrite --platform=mas --arch=x64 --download.mirrorOptions.mirror=https://registry.npmmirror.com/electron/  --electron-version=16.2.2"
+    "package_all": "electron-packager ./ bbg --asar --overwrite --platform=win32,linux,darwin,mas  --arch=x64 --download.mirrorOptions.mirror=https://npmmirror.com/mirrors/electron/ --electron-version=16.2.2",
+    "package_windows": "electron-packager ./ bbg --asar --overwrite --platform=win32  --arch=x64 --download.mirrorOptions.mirror=https://npmmirror.com/mirrors/electron/ --electron-version=16.2.2",
+    "package_linux": "electron-packager ./ bbg --asar --overwrite --platform=linux  --arch=x64 --download.mirrorOptions.mirror=https://npmmirror.com/mirrors/electron/  --electron-version=16.2.2",
+    "package_darwin": "electron-packager ./ bbg --asar --overwrite --platform=darwin  --arch=x64 --download.mirrorOptions.mirror=https://npmmirror.com/mirrors/electron/  --electron-version=16.2.2",
+    "package_mas": "electron-packager ./ bbg --asar --overwrite --platform=mas --arch=x64 --download.mirrorOptions.mirror=https://npmmirror.com/mirrors/electron/  --electron-version=16.2.2"
   },
   "author": "baiyang-lzy",
   "license": "UNLICENSED",

--- a/package.json
+++ b/package.json
@@ -7,21 +7,21 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "electron ./main.js",
     "dev": "electron ./main_dev.js",
-    "package_all": "electron-packager ./ bbg --asar --overwrite --platform=win32,linux,darwin,mas  --arch=x64 --download.mirrorOptions.mirror=https://npm.taobao.org/mirrors/electron/ --electron-version=16.0.6",
-    "package_windows": "electron-packager ./ bbg --asar --overwrite --platform=win32  --arch=x64 --download.mirrorOptions.mirror=https://npm.taobao.org/mirrors/electron/ --electron-version=16.0.6",
-    "package_linux": "electron-packager ./ bbg --asar --overwrite --platform=linux  --arch=x64 --download.mirrorOptions.mirror=https://npm.taobao.org/mirrors/electron/  --electron-version=16.0.6",
-    "package_darwin": "electron-packager ./ bbg --asar --overwrite --platform=darwin  --arch=x64 --download.mirrorOptions.mirror=https://npm.taobao.org/mirrors/electron/  --electron-version=16.0.6",
-    "package_mas": "electron-packager ./ bbg --asar --overwrite --platform=mas --arch=x64 --download.mirrorOptions.mirror=https://npm.taobao.org/mirrors/electron/  --electron-version=16.0.6"
+    "package_all": "electron-packager ./ bbg --asar --overwrite --platform=win32,linux,darwin,mas  --arch=x64 --download.mirrorOptions.mirror=https://registry.npmmirror.com/electron/ --electron-version=16.2.2",
+    "package_windows": "electron-packager ./ bbg --asar --overwrite --platform=win32  --arch=x64 --download.mirrorOptions.mirror=https://registry.npmmirror.com/electron/ --electron-version=16.2.2",
+    "package_linux": "electron-packager ./ bbg --asar --overwrite --platform=linux  --arch=x64 --download.mirrorOptions.mirror=https://registry.npmmirror.com/electron/  --electron-version=16.2.2",
+    "package_darwin": "electron-packager ./ bbg --asar --overwrite --platform=darwin  --arch=x64 --download.mirrorOptions.mirror=https://registry.npmmirror.com/electron/  --electron-version=16.2.2",
+    "package_mas": "electron-packager ./ bbg --asar --overwrite --platform=mas --arch=x64 --download.mirrorOptions.mirror=https://registry.npmmirror.com/electron/  --electron-version=16.2.2"
   },
   "author": "baiyang-lzy",
   "license": "UNLICENSED",
   "devDependencies": {
-    "electron": "^16.2.1",
+    "electron": "^16.2.2",
     "electron-packager": "^15.4.0"
   },
   "dependencies": {
     "@electron/remote": "^2.0.8",
-    "@popperjs/core": "^2.11.4",
+    "@popperjs/core": "^2.11.5",
     "bootstrap": "5.0.2",
     "electron-json-storage": "^4.5.0",
     "express": "^4.17.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,9 +2,9 @@ lockfileVersion: 5.3
 
 specifiers:
   '@electron/remote': ^2.0.8
-  '@popperjs/core': ^2.11.4
+  '@popperjs/core': ^2.11.5
   bootstrap: 5.0.2
-  electron: ^16.2.1
+  electron: ^16.2.2
   electron-json-storage: ^4.5.0
   electron-packager: ^15.4.0
   express: ^4.17.3
@@ -12,16 +12,16 @@ specifiers:
   request: ^2.88.2
 
 dependencies:
-  '@electron/remote': 2.0.8_electron@16.2.1
-  '@popperjs/core': 2.11.4
-  bootstrap: 5.0.2_@popperjs+core@2.11.4
+  '@electron/remote': 2.0.8_electron@16.2.2
+  '@popperjs/core': 2.11.5
+  bootstrap: 5.0.2_@popperjs+core@2.11.5
   electron-json-storage: 4.5.0
   express: 4.17.3
   font-awesome: 4.7.0
   request: 2.88.2
 
 devDependencies:
-  electron: 16.2.1
+  electron: 16.2.2
   electron-packager: 15.4.0
 
 packages:
@@ -44,12 +44,12 @@ packages:
       - supports-color
     dev: true
 
-  /@electron/remote/2.0.8_electron@16.2.1:
+  /@electron/remote/2.0.8_electron@16.2.2:
     resolution: {integrity: sha512-P10v3+iFCIvEPeYzTWWGwwHmqWnjoh8RYnbtZAb3RlQefy4guagzIwcWtfftABIfm6JJTNQf4WPSKWZOpLmHXw==}
     peerDependencies:
       electron: '>= 13.0.0'
     dependencies:
-      electron: 16.2.1
+      electron: 16.2.2
     dev: false
 
   /@malept/cross-spawn-promise/1.1.1:
@@ -59,8 +59,8 @@ packages:
       cross-spawn: 7.0.3
     dev: true
 
-  /@popperjs/core/2.11.4:
-    resolution: {integrity: sha512-q/ytXxO5NKvyT37pmisQAItCFqA7FD/vNb8dgaJy3/630Fsc+Mz9/9f2SziBoIZ30TJooXyTwZmhi1zjXmObYg==}
+  /@popperjs/core/2.11.5:
+    resolution: {integrity: sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==}
     dev: false
 
   /@sindresorhus/is/0.14.0:
@@ -217,12 +217,12 @@ packages:
     dev: true
     optional: true
 
-  /bootstrap/5.0.2_@popperjs+core@2.11.4:
+  /bootstrap/5.0.2_@popperjs+core@2.11.5:
     resolution: {integrity: sha512-1Ge963tyEQWJJ+8qtXFU6wgmAVj9gweEjibUdbmcCEYsn38tVwRk8107rk2vzt6cfQcRr3SlZ8aQBqaD8aqf+Q==}
     peerDependencies:
       '@popperjs/core': ^2.9.2
     dependencies:
-      '@popperjs/core': 2.11.4
+      '@popperjs/core': 2.11.5
     dev: false
 
   /brace-expansion/1.1.11:
@@ -509,14 +509,14 @@ packages:
       plist: 3.0.5
       rcedit: 3.0.1
       resolve: 1.22.0
-      semver: 7.3.5
+      semver: 7.3.6
       yargs-parser: 20.2.9
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /electron/16.2.1:
-    resolution: {integrity: sha512-hkVZuV+Dei67eSl/xxCykZXNcHJS5OGVZI0QdSgEoSsUxLWBohD2E85XFrkNQ0A2W2HcYNausrog+It7U8Af7w==}
+  /electron/16.2.2:
+    resolution: {integrity: sha512-MOZCewpDvhiuYCw8UnJnQxU/9cni4tlHHWBdi0JWbcdBOrGsDMSt17nuPwR5wSf1e7mSfofGIUPg9iHS5KA8Eg==}
     engines: {node: '>= 8.6'}
     hasBin: true
     requiresBuild: true
@@ -732,7 +732,7 @@ packages:
   /fs-extra/4.0.3:
     resolution: {integrity: sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==}
     dependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
       jsonfile: 4.0.0
       universalify: 0.1.2
     dev: true
@@ -741,7 +741,7 @@ packages:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
     dependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
       jsonfile: 4.0.0
       universalify: 0.1.2
     dev: true
@@ -750,7 +750,7 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
     dependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
       jsonfile: 4.0.0
       universalify: 0.1.2
     dev: true
@@ -760,7 +760,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       at-least-node: 1.0.0
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
       jsonfile: 6.1.0
       universalify: 2.0.0
     dev: true
@@ -831,7 +831,7 @@ packages:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.3.5
+      semver: 7.3.6
       serialize-error: 7.0.1
     dev: true
     optional: true
@@ -873,8 +873,8 @@ packages:
       url-parse-lax: 3.0.0
     dev: true
 
-  /graceful-fs/4.2.9:
-    resolution: {integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==}
+  /graceful-fs/4.2.10:
+    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
 
   /har-schema/2.0.0:
     resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
@@ -1024,7 +1024,7 @@ packages:
   /jsonfile/4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
     optionalDependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
     dev: true
 
   /jsonfile/6.1.0:
@@ -1032,7 +1032,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
     dev: true
 
   /jsprim/1.4.2:
@@ -1060,7 +1060,7 @@ packages:
     resolution: {integrity: sha512-3p6ZOGNbiX4CdvEd1VcE6yi78UrGNpjHO33noGwHCnT/o2fyllJDepsm8+mFFv/DvtwFHht5HIHSyOy5a+ChVQ==}
     engines: {node: '>=4'}
     dependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
       parse-json: 2.2.0
       pify: 2.3.0
       strip-bom: 3.0.0
@@ -1097,11 +1097,9 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /lru-cache/6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
-    engines: {node: '>=10'}
-    dependencies:
-      yallist: 4.0.0
+  /lru-cache/7.8.0:
+    resolution: {integrity: sha512-AmXqneQZL3KZMIgBpaPTeI6pfwh+xQ2vutMsyqOu1TBdEXFZgpG/80wuJ531w2ZN7TI0/oc8CPxzh/DKQudZqg==}
+    engines: {node: '>=12'}
     dev: true
 
   /matcher/3.0.0:
@@ -1515,12 +1513,12 @@ packages:
     hasBin: true
     dev: true
 
-  /semver/7.3.5:
-    resolution: {integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==}
-    engines: {node: '>=10'}
+  /semver/7.3.6:
+    resolution: {integrity: sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==}
+    engines: {node: ^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      lru-cache: 6.0.0
+      lru-cache: 7.8.0
     dev: true
 
   /send/0.17.2:
@@ -1797,7 +1795,7 @@ packages:
   /write-file-atomic/2.4.3:
     resolution: {integrity: sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==}
     dependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
     dev: false
@@ -1805,10 +1803,6 @@ packages:
   /xmlbuilder/9.0.7:
     resolution: {integrity: sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==}
     engines: {node: '>=4.0'}
-    dev: true
-
-  /yallist/4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: true
 
   /yargs-parser/20.2.9:


### PR DESCRIPTION
The mirror [https://npm.taobao.org](https://npm.taobao.org) won't be supported on June 30th ,2022. They use a new domain: [https://npmmirror.com](https://npmmirror.com). But the old one will be redirected to the new one till it become unsupported.
More info, please see [their website](https://npmmirror.com) and [the announcement](https://zhuanlan.zhihu.com/p/465424728/)