### PR TITLE
feat: auto migrate & publish demo site

### DIFF
--- a/.github/workflows/migrate_publish.yml
+++ b/.github/workflows/migrate_publish.yml
@@ -1,0 +1,52 @@
+name: Migrate and publish demo site
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  migrate-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout source"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: "Checkout demo site"
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ secrets.DEPLOY_REPO }}
+          ref: ${{ secrets.DEPLOY_BRANCH }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+          path: demo-site
+
+      - name: "Setup Node.js"
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: 'yarn'
+
+      - name: "Install dependencies"
+        run: |
+          yarn install --frozen-lockfile
+
+      - name: "Configure environment"
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: "Migrate"
+        run: |
+          export ROOT_DIR="$(pwd)/demo-site"
+          export COMMIT_SHA_SHORT="$(git rev-parse --short HEAD)"
+          node App/migrate_ci.js
+
+      - name: "Publish"
+        run: |
+          cd demo-site
+          git add .
+          git commit -m "Auto-commit from CI: ${GITHUB_SHA}"
+          git push

--- a/App/migrate_ci.js
+++ b/App/migrate_ci.js
@@ -1,0 +1,22 @@
+const fs = require("fs");
+
+process.chdir("./App");
+const BlogData = require("./BlogData.js");
+const migrate = require("./migrate_cli.js");
+
+
+rootDir = process.env.ROOT_DIR;
+const BlogInstance = new BlogData(rootDir);
+blog = BlogInstance.getBlogData();
+migrate();
+
+const d = new Date();
+let date = d.getFullYear() + "-" + ((d.getMonth() + 1).toString().padStart(2, '0')) + "-" + ((d.getDate()).toString().padStart(2, '0'));
+let time = (d.getHours().toString().padStart(2, '0')) + ":" + (d.getMinutes().toString().padStart(2, '0')) + ":" + (d.getSeconds().toString().padStart(2, '0'));
+let dateTime = date + ' ' + time;
+
+const commitSHAShort = process.env.COMMIT_SHA_SHORT;
+const githubRepository = process.env.GITHUB_REPOSITORY;
+let blog_settings_bottom_information = `Deployed on ${dateTime} ([${commitSHAShort}](https://github.com/${githubRepository}/commit/${commitSHAShort}))`;
+blog["底部信息（格式为markdown）"] = blog_settings_bottom_information;
+BlogInstance.writeBlogData();

--- a/App/migrate_cli.js
+++ b/App/migrate_cli.js
@@ -1,0 +1,280 @@
+const fs = require("fs");
+const { constants } = require("fs");
+const currentProgramVersion = require("./currentProgramVersion.js");
+
+function updateBlogIndexHtml() {
+  if (
+    blog["全局主题设置"]["是否使用第三方主题"] === false
+  ) {
+    fs.rmSync(`${rootDir}/index.html`);
+    fs.copyFileSync(
+      __dirname + "/blog_source/index.html",
+      rootDir + "/index.html",
+      constants.COPYFILE_EXCL
+    );
+  }
+}
+
+function addSupportOfMultiLanguage() {
+  blog["网站语言"] = "简体中文";
+}
+
+function check_third_party_theme_compatiblity() {
+  if (
+    blog["全局主题设置"]["是否使用第三方主题"] === true &&
+    blog["全局主题设置"]["若使用第三方主题，是否来自本地文件"] === false &&
+    blog["全局主题设置"]["若使用来自主题商店的第三方主题，则主题的更新发布日期为"] !== "" &&
+    blog["全局主题设置"]["若使用来自主题商店的第三方主题，则主题的更新发布日期为"] < 20211002
+  ) {
+    console.warn("由于你正在使用不受支持的第三方主题，已经重置为官方主题。");
+    thirdPartyThemeReset();
+  }
+}
+
+function cleanStaticRes() {
+  delete blog["静态资源"];
+  delete blog["全局主题设置"]["若使用背景图像，设置为"][
+    "将/static/background.webp作为背景图像"
+  ];
+  blog["全局主题设置"]["若使用背景图像，设置为"][
+    "将网站根目录下的background.webp作为背景图像"
+  ] = false;
+
+  if (fs.existsSync(`${rootDir}/static/`)) {
+    fs.rmSync(`${rootDir}/static/`, { recursive: true, force: true });
+  }
+}
+
+function addSupportForPublicCommentService() {
+  blog["全局评论设置"]["valine设置"]["是否使用bbg公共评论服务"] = false;
+}
+
+function addSupportForAnnouncementBoard() {
+  blog["启用网站公告"] = false;
+  blog["网站公告仅在首页显示"] = true;
+  blog["网站公告"] = "";
+}
+
+function addSupportOfFriendBook() {
+  blog["启用内建友人帐页面"] = true;
+  blog["友人帐页面附加信息"] = "";
+  blog["友人帐"] = [];
+  blog["友人帐页面允许评论"] = true;
+}
+
+function thirdPartyThemeReset() {
+  blog["全局主题设置"]["是否使用第三方主题"] = false;
+  blog["全局主题设置"]["若使用第三方主题，是否来自本地文件"] = false;
+  blog["全局主题设置"]["若使用来自主题商店的第三方主题，则主题名为"] = "";
+  blog["全局主题设置"][
+    "若使用来自主题商店的第三方主题，则主题的更新发布日期为"
+  ] = "";
+}
+
+function addSupportForCDNSetting() {
+  blog["CDN选择"] = 1;
+  blog["CDN路径"] = "https://cdn.jsdelivr.net/npm";
+}
+
+function addSupportForCustomCJ() {
+  blog["启用自定义CSS"] = false;
+  blog["启用自定义JS"] = false;
+  blog["自定义CSS"] = "";
+  blog["自定义JS"] = "";
+}
+
+function addSupportOfArticlePageOrder() {
+  blog["文章列表中每页的文章数为"] = 10;
+}
+
+function addSupportForContentLicense() {
+  blog["全站内容授权协议"] = "reserved";
+  blog["不使用全站内容授权协议"] = false;
+}
+
+function addSupportForArticleBottomExternalOptions() {
+  blog["文章页面显示上一篇下一篇文章导航按钮"] = true;
+  blog["提供文章文件下载"] = false;
+  blog["提供复制全文到剪贴板的选项"] = false;
+}
+
+module.exports = function () {
+  let currentBlogVersion = parseInt(
+    blog["博客程序版本（禁止修改此值，否则会导致跨版本升级异常）"],
+    10
+  );
+
+  // 如果不包含有效的博客数据文件
+
+  if (
+    currentBlogVersion === undefined ||
+    currentBlogVersion === null ||
+    currentBlogVersion === ""
+  ) {
+    console.error("博客数据文件不包含有效的版本号信息（ERR_NO_VERSION）");
+    console.error("博客数据文件可能已经损坏。");
+    process.exit(1);
+  } else {
+    if (
+      blog["博客程序版本（禁止修改此值，否则会导致跨版本升级异常）"] > currentProgramVersion
+    ) {
+      console.error("不兼容此版本的博客数据文件（ERR_BAD_VERSION）");
+      console.error("检测到新版数据文件。请使用新版 BBG 管理站点，以免损坏数据。");
+      process.exit(1);
+    }
+
+    blog["博客程序版本（禁止修改此值，否则会导致跨版本升级异常）"] = currentProgramVersion;
+
+    if (currentBlogVersion <= 20210812) {
+      thirdPartyThemeReset();
+      cleanStaticRes();
+      addSupportForPublicCommentService();
+      addSupportOfMultiLanguage();
+      addSupportForAnnouncementBoard();
+      addSupportOfFriendBook();
+      addSupportForCDNSetting();
+      addSupportForCustomCJ();
+      addSupportOfArticlePageOrder();
+      addSupportForContentLicense();
+      addSupportForArticleBottomExternalOptions();
+    }
+
+    if (currentBlogVersion <= 20210817 && currentBlogVersion >= 20210813) {
+      thirdPartyThemeReset();
+
+      cleanStaticRes();
+      addSupportForPublicCommentService();
+      addSupportOfMultiLanguage();
+      addSupportForAnnouncementBoard();
+      addSupportOfFriendBook();
+      addSupportForCDNSetting();
+      addSupportForCustomCJ();
+      addSupportOfArticlePageOrder();
+      addSupportForContentLicense();
+      addSupportForArticleBottomExternalOptions();
+    }
+
+    if (
+      currentBlogVersion === 20210819 ||
+      currentBlogVersion === 20210822 ||
+      currentBlogVersion === 20210826 ||
+      currentBlogVersion === 20210825 ||
+      currentBlogVersion === 20210828
+    ) {
+      thirdPartyThemeReset();
+      addSupportForPublicCommentService();
+      addSupportOfMultiLanguage();
+      addSupportForAnnouncementBoard();
+      addSupportOfFriendBook();
+      addSupportForCDNSetting();
+      addSupportForCustomCJ();
+      addSupportOfArticlePageOrder();
+      addSupportForContentLicense();
+      addSupportForArticleBottomExternalOptions();
+    }
+
+    if (currentBlogVersion === 20210925) {
+      thirdPartyThemeReset();
+      addSupportOfMultiLanguage();
+      addSupportForAnnouncementBoard();
+      addSupportOfFriendBook();
+      addSupportForCDNSetting();
+      addSupportForCustomCJ();
+      addSupportOfArticlePageOrder();
+      addSupportForContentLicense();
+      addSupportForArticleBottomExternalOptions();
+    }
+
+    if (currentBlogVersion === 20211002 || currentBlogVersion === 20211003 || currentBlogVersion === 20211016 || currentBlogVersion === 20211022 || currentBlogVersion === 20211106) {
+      check_third_party_theme_compatiblity();
+      addSupportOfMultiLanguage();
+      addSupportForAnnouncementBoard();
+      addSupportOfFriendBook();
+      addSupportForCDNSetting();
+      addSupportForCustomCJ();
+      addSupportOfArticlePageOrder();
+      addSupportForContentLicense();
+      addSupportForArticleBottomExternalOptions();
+    }
+
+    if (currentBlogVersion === 20211205) {
+      check_third_party_theme_compatiblity();
+      addSupportOfMultiLanguage();
+      addSupportForAnnouncementBoard();
+      addSupportOfFriendBook();
+      addSupportForCDNSetting();
+      addSupportForCustomCJ();
+      addSupportOfArticlePageOrder();
+      addSupportForContentLicense();
+      addSupportForArticleBottomExternalOptions();
+    }
+
+    if (currentBlogVersion === 20220119) {
+      check_third_party_theme_compatiblity();
+      addSupportForAnnouncementBoard();
+      addSupportOfFriendBook();
+      addSupportForCDNSetting();
+      addSupportForCustomCJ();
+      addSupportOfArticlePageOrder();
+      addSupportForContentLicense();
+      addSupportForArticleBottomExternalOptions();
+    }
+    if (currentBlogVersion === 20220123) {
+      check_third_party_theme_compatiblity();
+      addSupportOfFriendBook();
+      addSupportForCDNSetting();
+      addSupportForCustomCJ();
+      addSupportOfArticlePageOrder();
+      addSupportForContentLicense();
+      addSupportForArticleBottomExternalOptions();
+    }
+
+    if (currentBlogVersion === 20220202) {
+      check_third_party_theme_compatiblity();
+      addSupportForCDNSetting();
+      addSupportForCustomCJ();
+      addSupportOfArticlePageOrder();
+      addSupportForContentLicense();
+      addSupportForArticleBottomExternalOptions();
+    }
+    if (currentBlogVersion === 20220210) {
+      check_third_party_theme_compatiblity();
+      addSupportForCustomCJ();
+      addSupportOfArticlePageOrder();
+      addSupportForContentLicense();
+      addSupportForArticleBottomExternalOptions();
+    }
+    if (currentBlogVersion === 20220211 || currentBlogVersion === 20220212) {
+      check_third_party_theme_compatiblity();
+      addSupportOfArticlePageOrder();
+      addSupportForContentLicense();
+      addSupportForArticleBottomExternalOptions();
+    }
+
+    if (currentBlogVersion === 20220213) {
+      check_third_party_theme_compatiblity();
+      addSupportOfArticlePageOrder();
+      addSupportForContentLicense();
+      addSupportForArticleBottomExternalOptions();
+    }
+
+    if (currentBlogVersion === 20220304) {
+      check_third_party_theme_compatiblity();
+      addSupportForContentLicense();
+      addSupportForArticleBottomExternalOptions();
+    }
+
+    if (currentBlogVersion >= 20220314 && currentBlogVersion <= 20220604) {
+      check_third_party_theme_compatiblity();
+      addSupportForArticleBottomExternalOptions();
+    }
+
+    check_third_party_theme_compatiblity();
+    updateBlogIndexHtml();
+
+
+    fs.writeFileSync(rootDir + "/data/index.json", JSON.stringify(blog));
+
+    console.log("博客数据更新成功。");
+  }
+};


### PR DESCRIPTION
Automatically migrate and publish the demo site with the latest commit.


Suppose the demo site is at baiyang-lzy/testblog, these configurations are required:

1. Generate one pair of ssh keys through the `ssh-keygen` command for pushing to the demo site repository
2. Add ssh public key to [Deploy keys of baiyang-lzy/testblog](https://github.com/baiyang-lzy/testblog/settings/keys) with write access checked
3. Add secrets to [Actions secrets of baiyang-lzy/bbg](https://github.com/baiyang-lzy/bbg/settings/secrets/actions)
  - `DEPLOY_REPO`: `baiyang-lzy/testblog`
  - `DEPLOY_BRANCH`: `main`
  - `DEPLOY_KEY`: ssh private key
4. (optional) rm/mv local ssh keys